### PR TITLE
Deprecate Tmux Powerline

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,6 @@ cd into the `dotfiles` directory, and then run:
 ./assimilate.sh
 ```
 
+### Tmux Plugin Manager
+- Install Tmux Plugin Manager ([Github](https://github.com/tmux-plugins/tpm#tmux-plugin-manager))
+- Install tmux packages with `prefix + I`

--- a/assimilate.sh
+++ b/assimilate.sh
@@ -10,12 +10,14 @@ function sym () {
   src="$DOTFILES/$1"
   dest="$PREFIX/$2"
 
+  # Save existing dotfiles
   if [ -e "$dest" ]; then
     newdest="$BACKUPS/$(basename $dest)-$(date +%s)"
     mv "$dest" "$newdest"
     echo "> Moved $dest to $newdest"
   fi
 
+  # Symlink new dotfiles
   ln -s "$src" "$dest"
 }
 
@@ -24,7 +26,6 @@ if [ ! -e "$DOTFILES" ]; then
   exit 1
 fi
 
-mkdir -p "$PREFIX"
 mkdir -p "$BACKUPS/vim_backups"
 
 sym bashrc              .bashrc

--- a/tmux.conf
+++ b/tmux.conf
@@ -26,22 +26,12 @@ unbind C-Down
 unbind C-Left
 unbind C-Right
 
-# Tmux Powerline
-set-option -g status on
-set-option -g status-interval 2
-set-option -g status-justify "centre"
-set-option -g status-left-length 60
-set-option -g status-right-length 90
-set-option -g status-left "#(~/dotfiles/tmux-powerline/powerline.sh left)"
-set-option -g status-right "#(~/dotfiles/tmux-powerline/powerline.sh right)"
-
 # Make window titles basename of current directory
 setw -g automatic-rename-format "#{b:pane_current_path}"
 
 # prettifies the window-status segments
 # Create hook to automatically split panes when creating new session
 set-hook -g session-created '\
-    run-shell "~/dotfiles/tmux-powerline/powerline.sh init"; \
     split -h -p 35; \
     split -v -p 45; \
     select-pane -L;
@@ -59,7 +49,6 @@ set-option -g repeat-time 250
 # Plugins
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-sensible'
-set -g @plugin 'erikw/tmux-powerline'
 
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 run '~/.tmux/plugins/tpm/tpm'


### PR DESCRIPTION
## Summary
- Deprecating `tmux-powerline`
- Adding installation instructions for `tpm`

## Test Plan
- `prefix + I` only installs the expected plugins
<img width="334" alt="image" src="https://github.com/akan72/dotfiles/assets/29241719/51218459-3455-41bc-8aa4-544508e26b90">
