### PR TITLE
Add Zed Keymappings and Update Tmux Set Alias

### DIFF
--- a/assimilate.sh
+++ b/assimilate.sh
@@ -44,6 +44,7 @@ sym ghostty/config      Library/Application\ Support/com.mitchellh.ghostty/confi
 sym tmux-powerline/config.sh   .config/tmux-powerline/config.sh
 sym tmux-powerline/themes/theme.sh  .config/tmux-powerline/themes/theme.sh
 sym claude/statusline.sh .claude/statusline.sh
+sym zed/keymap.json     .config/zed/keymap.json
 
 brew bundle install
 echo "> Assimilation successful!"

--- a/tmux.conf
+++ b/tmux.conf
@@ -1,11 +1,11 @@
 # Set default shell to zsh
-set-option -g default-shell /bin/zsh
+set -g default-shell /bin/zsh
 
 # Reassign prefix and turn on mouse
 set -g status on
 set -g prefix C-a
 unbind-key C-b
-set-option -g mouse on
+set -g mouse on
 
 # Fix ESC Tmux + Neovim lag issue
 set -sg escape-time 10
@@ -30,7 +30,7 @@ unbind C-Right
 setw -g automatic-rename-format "#{b:pane_current_path}"
 
 # Decrease prefix timeout
-set-option -g repeat-time 250
+set -g repeat-time 250
 
 # Plugins
 set -g @plugin 'tmux-plugins/tpm'
@@ -40,14 +40,14 @@ set -g @plugin 'erikw/tmux-powerline'
 run '~/.tmux/plugins/tpm/tpm'
 
 # Tmux Powerline
-set-option -g status on
-set-option -g status-interval 2
-set-option -g status-left "#(~/.tmux/plugins/tmux-powerline/powerline.sh left)"
-set-option -g status-right "#(~/.tmux/plugins/tmux-powerline/powerline.sh right)"
+set -g status on
+set -g status-interval 2
+set -g status-left "#(~/.tmux/plugins/tmux-powerline/powerline.sh left)"
+set -g status-right "#(~/.tmux/plugins/tmux-powerline/powerline.sh right)"
 
-set-option -g status-left-length 60
-set-option -g status-right-length 90
-set-option -g status-justify "centre"
+set -g status-left-length 60
+set -g status-right-length 90
+set -g status-justify "centre"
 
 # Create hook to automatically split panes when creating new session
 set-hook -g session-created '\
@@ -61,6 +61,9 @@ set-hook -g 'after-new-window' '\
     split -v -l 25 -c "#{pane_current_path}"; \
     select-pane -L;
 '
+
+# Set focus-events on for Claude Code state management
+set -g focus-events on
 
 # Set up custom theme
 # Theme:  dotfiles/tmux-powerline/themes/theme.sh    (loaded by plugin via $XDG_CONFIG_HOME/tmux-powerline/themes/)

--- a/zed/keymap.json
+++ b/zed/keymap.json
@@ -1,0 +1,14 @@
+[
+  {
+    "context": "Workspace",
+    "bindings": {
+        "ctrl-a h": "workspace::ActivatePaneLeft",
+        "ctrl-a l": "workspace::ActivatePaneRight",
+        "ctrl-a j": "workspace::ActivatePaneDown",
+        "ctrl-a k": "workspace::ActivatePaneUp"
+    }
+  },
+  {
+    "context": "Editor && vim_mode == insert"
+  }
+]


### PR DESCRIPTION
## Summary
- Symlink zed keymappings
- Enforce consistency with `set` over `set-option` in `tmux.conf`
- Add `set -g focus-events on` for Claude Code