### PR TITLE
Prepend hostname to zsh prompt over SSH

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -41,6 +41,7 @@ source $ZSH/oh-my-zsh.sh
 # Preferred editor for local and remote sessions
 if [[ -n $SSH_CONNECTION ]]; then
   export EDITOR='vim'
+  PROMPT="%F{yellow}[%m]%f $PROMPT"
 else
   export EDITOR='nvim'
 fi


### PR DESCRIPTION
## Summary

- Prepends `[<hostname>]` in yellow to `$PROMPT` only when `$SSH_CONNECTION` is set, so it's clear at a glance which host you're shelling on.
- Local prompt is unchanged.

## Test plan

- [x] `ssh` into a host running this `zshrc` — prompt shows `[hostname]` prefix in yellow.
- [x] Local terminal — prompt unchanged from `robbyrussell` default.
<img width="195" height="33" alt="image" src="https://github.com/user-attachments/assets/45bab444-2aac-4339-a64c-116662bea374" />
