### PR TITLE
Exclude Additional Files from Zed Settings

### DIFF
--- a/zed/settings.json
+++ b/zed/settings.json
@@ -56,6 +56,10 @@
         "git_status": true
     },
     "file_scan_exclusions": [
+        // Claude Worktrees
+        "**/.claude/worktrees/**",
+        // dbt
+        "**/manifest.json",
         // Scan python generated files
         "**/.ruff_cache",
         "__pycache__",


### PR DESCRIPTION
## Summary
- Exclude files in Claude Worktrees and dbt's `manifest.json` from zed search