### PR TITLE
Harden gitconfig with portable SSH commit + tag signing

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -2,15 +2,25 @@
 	email = 29241719+akan72@users.noreply.github.com
 	name = Alex Kan
 	username = akan72
-	# SSH signing key (public key path). Upload this key to GitHub as a
-	# *signing* key (Settings > SSH and GPG keys > New SSH key > type "Signing").
-	signingkey = ~/.ssh/id_ed25519.pub
+	# signingkey intentionally unset — resolved at sign time by
+	# gpg.ssh.defaultKeyCommand below, which pulls the first key from ssh-agent.
+	# Whichever key it picks must be uploaded to GitHub as a *signing* key
+	# (Settings > SSH and GPG keys > New SSH key > type "Signing").
 
 [gpg]
 	# Sign with SSH keys rather than GPG — reuses the SSH key already used for
 	# auth, so there is no separate GPG keyring to manage (works the same on a
 	# remote box, e.g. EC2, as long as the key is present or agent-forwarded).
 	format = ssh
+
+[gpg "ssh"]
+	# Portable across machines: read the first key from whichever ssh-agent
+	# is currently exposed (macOS system agent, 1Password, gpg-agent, etc.)
+	# rather than hardcoding ~/.ssh/id_ed25519.pub. Works with hardware-
+	# resident keys (YubiKey ed25519-sk, 1Password) where there may be no
+	# .pub file on disk. The `key::` prefix is what git's source explicitly
+	# looks for in defaultKeyCommand output.
+	defaultKeyCommand = sh -c 'printf "key::%s\n" "$(ssh-add -L | head -n1)"'
 
 [commit]
 	gpgsign = true

--- a/gitconfig
+++ b/gitconfig
@@ -2,6 +2,21 @@
 	email = 29241719+akan72@users.noreply.github.com
 	name = Alex Kan
 	username = akan72
+	# SSH signing key (public key path). Upload this key to GitHub as a
+	# *signing* key (Settings > SSH and GPG keys > New SSH key > type "Signing").
+	signingkey = ~/.ssh/id_ed25519.pub
+
+[gpg]
+	# Sign with SSH keys rather than GPG — reuses the SSH key already used for
+	# auth, so there is no separate GPG keyring to manage (works the same on a
+	# remote box, e.g. EC2, as long as the key is present or agent-forwarded).
+	format = ssh
+
+[commit]
+	gpgsign = true
+
+[tag]
+	gpgsign = true
 
 [core]
 	editor = nvim


### PR DESCRIPTION
## Summary

Harden `gitconfig` with **SSH-based** commit + tag signing, resolved at sign-time so the same config works across machines without per-host edits.

- `gpg.format = ssh` — sign with SSH keys instead of GPG (no keyring to manage)
- `gpg.ssh.defaultKeyCommand` — pulls the first key from whichever `ssh-agent` is exposed on the current machine, rather than hardcoding `~/.ssh/id_ed25519.pub`
- `user.signingkey` left **unset** (resolved by `defaultKeyCommand`)
- `commit.gpgsign = true` and `tag.gpgsign = true` — signed by default; GitHub shows the **Verified** badge

```
[gpg]
    format = ssh

[gpg "ssh"]
    defaultKeyCommand = sh -c 'printf "key::%s\n" "$(ssh-add -L | head -n1)"'

[commit]
    gpgsign = true

[tag]
    gpgsign = true
```

## Why dynamic resolution (vs hardcoded path)

A previous version of this PR set `user.signingkey = ~/.ssh/id_ed25519.pub`. That path doesn't exist on every machine (e.g. the current laptop only has `~/.ssh/id_rsa.pub`), so signing would silently fail at commit time.

`defaultKeyCommand` resolves the key at sign-time by reading from `ssh-agent`, which means:

- **Portable across machines** with different key paths (`id_rsa`, `id_ed25519`, `id_ed25519_sk`, …) — no per-host override file.
- **Works with hardware-resident keys** (YubiKey `ed25519-sk`, 1Password's SSH agent) where there may be no `.pub` file on disk at all.
- **Survives switching agents** (macOS system agent → 1Password agent) without any `gitconfig` change — just change `SSH_AUTH_SOCK`.

The `key::` prefix is required: git's source (`gpg-interface.c`) explicitly searches the command output for that literal substring. Many tutorials show bare `ssh-add -L | head -n1`, which actually does **not** work in modern git. The `printf` wrapper adds the prefix.

## Action required after merge + re-assimilate

1. Confirm the key `ssh-add -L | head -n1` returns is the one you want for signing.
2. Upload that key to GitHub as a **Signing** key (Settings → SSH and GPG keys → New SSH key → type *Signing*). This is a separate registration from the existing Authentication key, even if it's the same key string.
3. On any remote host (e.g. EC2), ensure the same key is present in the agent there (or use `ForwardAgent`).

## Why & alternatives

| Change | Why | Alternatives |
| --- | --- | --- |
| `commit.gpgsign = true` | Signed commits prove authenticity; GitHub shows "Verified". | Skip if no signing key — would break commits. |
| `tag.gpgsign = true` | Tags are part of the release trust chain. | Lower priority — skip if tags don't matter. |
| `gpg.format = ssh` | SSH keys reuse the auth key; no separate GPG keyring to manage. | Stick with GPG if already working (wider tool support outside Git). |
| `defaultKeyCommand = ssh-add -L \| head -n1` | Portable; works with hardware-resident keys. | (a) Hardcode `user.signingkey = ~/.ssh/<file>.pub` — simpler but fragile across machines. (b) `[includeIf]` per-host override — more moving parts. |